### PR TITLE
Fix repository location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ryan Gorup <gorup@users.noreply.github.com>"]
 edition = "2018"
 description = "Tool for getting tax information for addresses in WA State."
 license = "NCSA"
-repository = "https://github.com/rust-lang/cargo/"
+repository = "https://github.com/gorup/wataxrate"
 keywords = ["tax", "taxes", "washington", "wa"]
 readme = "README.md"
 


### PR DESCRIPTION
This will fix the repository location so that it goes to the correct repo on crates.io.